### PR TITLE
Event Remittion Execution

### DIFF
--- a/destinations.go
+++ b/destinations.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+// Destination interface represent any target to which we want to send our event
+type Destination interface {
+	Send(event Event) bool
+}
+
+// MockDestination1: A destination that successeds 80% of the time and fails 20% of the time
+type MockDestination1 struct {
+}
+
+func (md *MockDestination1) Send(event Event) bool {
+	randNumber := rand.Intn(100)
+	if randNumber < 80 {
+		fmt.Printf("MockDestination1 Successfully received event: %v\n", event)
+		return true
+	}
+
+	fmt.Printf("Mockdestination1 failed to successfully receive event: %v\n", event)
+	return false
+}
+
+// MockDestination2:  A destination that introduces random delays (up to 2 seconds)
+type MockDestination2 struct {
+}
+
+func (md *MockDestination2) Send(event Event) bool {
+	randDuration := time.Duration(rand.Intn(2000) * int(time.Millisecond))
+	time.Sleep(randDuration)
+	fmt.Printf("MockDestination2 has successfully received event: %v\n", event)
+
+	return true
+}
+
+// MockDestination3: A destination that always succeeds and also logs the received event
+type MockDestination3 struct {
+}
+
+func (md *MockDestination3) Send(event Event) bool {
+	fmt.Printf("MockDestination3 has successfully received event: %v\n", event)
+	return true
+}
+
+// Mock function to simulate sending the event to a destination
+// Randomly returns success or failure
+func SendToDestination(event Event) bool {
+	destinations := []Destination{
+		&MockDestination1{},
+		&MockDestination2{},
+		&MockDestination3{},
+	}
+
+	for _, destination := range destinations {
+		success := destination.Send(event)
+		if !success {
+			return false // Event delivery failed for one of the destinations
+		}
+	}
+
+	return true
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "context"
+
+var (
+	rdb RedisClientInterface   // Redis Client
+	ctx = context.Background() // Global context Redis operation
+)
+
+func main() {
+	InitializingRedis() // Initializing the redis client
+	defer rdb.Close()   // Ensuring the redis client is closed when the program is exited
+}

--- a/process.go
+++ b/process.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"time"
+)
+
+// Event represent the structure for the coming event data
+type Event struct {
+	UserID  string `json:"user_id"`
+	PayLoad string `json:"payload"`
+}
+
+// FallEvent represents an event that has failed delivery, along with the count of retry attempts
+type FallEvent struct {
+	Event      Event
+	RetryCount int
+}
+
+// ProcessEvent continously tries to fetch events from Redis and Sends them to their destinations
+func ProcessEvent() {
+	for {
+		ProcessEvent()
+	}
+}
+
+// ProcessSingleEvent tries to fetch a single event from Redis and sends it to its destination
+func ProcessSingleEvent() {
+	// pop an event from the front of Redis list (blocking until one is available)
+	eventJSON, err := rdb.BLPop(ctx, 0*time.Second, "events").Result()
+	if err != nil {
+		log.Printf("Error fetching event from Redis: %v", err)
+		return
+	}
+
+	if len(eventJSON) < 2 {
+		log.Printf("Error: Unexpected BLPop result format")
+		return
+	}
+
+	var event Event
+	err = json.Unmarshal([]byte(eventJSON[1]), &event)
+	if err != nil {
+		log.Printf("Error Unmarshling event: %v", err)
+		return
+	}
+
+	// success := sendToDestination(event)
+	// if !success {
+	// 	log.Printf("Failed to deliver event: %v", event)
+	// 	scheduleRetry(failedEvent{
+	// 		Event: event,
+	// 		RetryCount: 1, // Intial retry attempt
+	// 	})
+	// }
+}

--- a/process.go
+++ b/process.go
@@ -46,12 +46,12 @@ func ProcessSingleEvent() {
 		return
 	}
 
-	// success := sendToDestination(event)
-	// if !success {
-	// 	log.Printf("Failed to deliver event: %v", event)
-	// 	scheduleRetry(failedEvent{
-	// 		Event: event,
-	// 		RetryCount: 1, // Intial retry attempt
-	// 	})
-	// }
+	success := SendToDestination(event)
+	if !success {
+		log.Printf("Failed to deliver event: %v", event)
+		// scheduleRetry(failedEvent{
+		// 	Event:      event,
+		// 	RetryCount: 1, // Intial retry attempt
+		// })
+	}
 }

--- a/redis_client.go
+++ b/redis_client.go
@@ -55,7 +55,14 @@ func (wrapper *RedisClientWrapper) LLen(ctx context.Context, key string) *redis.
 }
 
 func (wrapper *RedisClientWrapper) ZAdd(ctx context.Context, key string, members ...*redis.Z) *redis.IntCmd {
-	return wrapper.Client.ZAdd(ctx, key, members...)
+	// Unpack members and convert them to []redis.Z
+	zMembers := make([]redis.Z, len(members))
+	for i, member := range members {
+		zMembers[i] = *member
+	}
+
+	// Call ZAdd with individual elements
+	return wrapper.Client.ZAdd(ctx, key, zMembers...)
 }
 
 func (wrapper *RedisClientWrapper) ZRangeByScoreWithScores(ctx context.Context, key string, opt *redis.ZRangeBy) *redis.ZSliceCmd {


### PR DESCRIPTION
# What this PR does:
* Mock Destinations implementations to simulate how the events will be received under different circumstances.
* `SendToDestination` function to simulate sending the event to a destination.
* fixes the persisting `cannot use members (variable of type []*redis.Z) as []redis.Z value in argument to wrapper.Client.ZAdd` on the Redis client `ZAdd` function.
* 