### PR TITLE
Event Failure Retrial Addition

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,19 @@ var (
 	ctx = context.Background() // Global context Redis operation
 )
 
+const (
+	MaxRetries = 10 // Max attempts to retry sending an event
+)
+
 func main() {
 	InitializingRedis() // Initializing the redis client
 	defer rdb.Close()   // Ensuring the redis client is closed when the program is exited
+
+	// Start a Go routine for processing events.
+	go ProcessEvent()
+
+	// Start a separate routine to process failed events.
+	for i := 0; i < 10; i++ {
+		//go ProcessFailedEvents(i)
+	}
 }

--- a/process.go
+++ b/process.go
@@ -12,8 +12,8 @@ type Event struct {
 	PayLoad string `json:"payload"`
 }
 
-// FallEvent represents an event that has failed delivery, along with the count of retry attempts
-type FallEvent struct {
+// FailedEvent represents an event that has failed delivery, along with the count of retry attempts
+type FailedEvent struct {
 	Event      Event
 	RetryCount int
 }
@@ -49,9 +49,9 @@ func ProcessSingleEvent() {
 	success := SendToDestination(event)
 	if !success {
 		log.Printf("Failed to deliver event: %v", event)
-		// scheduleRetry(failedEvent{
-		// 	Event:      event,
-		// 	RetryCount: 1, // Intial retry attempt
-		// })
+		ScheduleRetry(FailedEvent{
+			Event:      event,
+			RetryCount: 1, // Intial retry attempt
+		})
 	}
 }

--- a/retry.go
+++ b/retry.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"math"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func ScheduleRetry(event FailedEvent) {
+	// Increase the retry count
+	event.RetryCount++
+
+	// if retries are exhausted, log and potentially alert
+	if event.RetryCount > MaxRetries {
+		log.Printf("Failed to deliver event after %d attempts: %v", MaxRetries, event.Event)
+		// NotifyAdmin("Event Delivery Failed", fmt.Printf("Failed to deliver event after %d attempts: %v", MaxRetries, event.Event))
+		return
+	}
+
+	// Calculate next retry time with exponential backoff
+	backOffDuration := time.Duration(math.Pow(2, float64(event.RetryCount))) * time.Second
+	retryTimestamp := time.Now().Add(backOffDuration).Unix()
+
+	eventJSON, _ := json.Marshal(event)
+	rdb.ZAdd(ctx, "retry_events", &redis.Z{
+		Score:  float64(retryTimestamp),
+		Member: eventJSON,
+	})
+}


### PR DESCRIPTION
# What this PR does :
* `FallEvent` making struct public
* `ScheduleRetry` schedules the failed event for a retry in the future
* Increase the retry count
* If retries are exhausted, log and potentially alert
* Start a Go routine for processing events.
* Setting  Max attempts to retry sending an event